### PR TITLE
fix issue1982: contains() exceptions are incorrectly raised

### DIFF
--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -678,6 +678,27 @@ class json_pointer
                         // "-" always fails the range check
                         return false;
                     }
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 and not (reference_token >= "0" and reference_token <= "9")))
+                    {
+                        // invalid char
+                        return false;
+                    }
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() > 1))
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(not (reference_token[0] > '0' and reference_token[0] <= '9')))
+                        {
+                            // first char should be between '1' and '9'
+                            return false;
+                        }
+                        for (std::size_t i = 1; i < reference_token.size(); i++)
+                        {
+                            if (JSON_HEDLEY_UNLIKELY(not (reference_token[i] >= '0' and reference_token[i] <= '9')))
+                            {
+                                // other char should be between '0' and '9'
+                                return false;
+                            }
+                        }
+                    }
 
                     const auto idx = static_cast<size_type>(array_index(reference_token));
                     if (idx >= ptr->size())

--- a/include/nlohmann/detail/json_pointer.hpp
+++ b/include/nlohmann/detail/json_pointer.hpp
@@ -678,21 +678,21 @@ class json_pointer
                         // "-" always fails the range check
                         return false;
                     }
-                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 and not (reference_token >= "0" and reference_token <= "9")))
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 and not ("0" <= reference_token and reference_token <= "9")))
                     {
                         // invalid char
                         return false;
                     }
                     if (JSON_HEDLEY_UNLIKELY(reference_token.size() > 1))
                     {
-                        if (JSON_HEDLEY_UNLIKELY(not (reference_token[0] > '0' and reference_token[0] <= '9')))
+                        if (JSON_HEDLEY_UNLIKELY(not ('1' <= reference_token[0] and reference_token[0] <= '9')))
                         {
                             // first char should be between '1' and '9'
                             return false;
                         }
                         for (std::size_t i = 1; i < reference_token.size(); i++)
                         {
-                            if (JSON_HEDLEY_UNLIKELY(not (reference_token[i] >= '0' and reference_token[i] <= '9')))
+                            if (JSON_HEDLEY_UNLIKELY(not ('0' <= reference_token[i] and reference_token[i] <= '9')))
                             {
                                 // other char should be between '0' and '9'
                                 return false;

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11081,6 +11081,27 @@ class json_pointer
                         // "-" always fails the range check
                         return false;
                     }
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 and not (reference_token >= "0" and reference_token <= "9")))
+                    {
+                        // invalid char
+                        return false;
+                    }
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() > 1))
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(not (reference_token[0] > '0' and reference_token[0] <= '9')))
+                        {
+                            // first char should be between '1' and '9'
+                            return false;
+                        }
+                        for (std::size_t i = 1; i < reference_token.size(); i++)
+                        {
+                            if (JSON_HEDLEY_UNLIKELY(not (reference_token[i] >= '0' and reference_token[i] <= '9')))
+                            {
+                                // other char should be between '0' and '9'
+                                return false;
+                            }
+                        }
+                    }
 
                     const auto idx = static_cast<size_type>(array_index(reference_token));
                     if (idx >= ptr->size())

--- a/single_include/nlohmann/json.hpp
+++ b/single_include/nlohmann/json.hpp
@@ -11081,21 +11081,21 @@ class json_pointer
                         // "-" always fails the range check
                         return false;
                     }
-                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 and not (reference_token >= "0" and reference_token <= "9")))
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 and not ("0" <= reference_token and reference_token <= "9")))
                     {
                         // invalid char
                         return false;
                     }
                     if (JSON_HEDLEY_UNLIKELY(reference_token.size() > 1))
                     {
-                        if (JSON_HEDLEY_UNLIKELY(not (reference_token[0] > '0' and reference_token[0] <= '9')))
+                        if (JSON_HEDLEY_UNLIKELY(not ('1' <= reference_token[0] and reference_token[0] <= '9')))
                         {
                             // first char should be between '1' and '9'
                             return false;
                         }
                         for (std::size_t i = 1; i < reference_token.size(); i++)
                         {
-                            if (JSON_HEDLEY_UNLIKELY(not (reference_token[i] >= '0' and reference_token[i] <= '9')))
+                            if (JSON_HEDLEY_UNLIKELY(not ('0' <= reference_token[i] and reference_token[i] <= '9')))
                             {
                                 // other char should be between '0' and '9'
                                 return false;

--- a/test/src/unit-json_pointer.cpp
+++ b/test/src/unit-json_pointer.cpp
@@ -310,12 +310,11 @@ TEST_CASE("JSON pointers")
             CHECK_THROWS_AS(j_const.at("/01"_json_pointer), json::parse_error&);
             CHECK_THROWS_WITH(j_const.at("/01"_json_pointer),
                               "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
-            CHECK_THROWS_AS(j.contains("/01"_json_pointer), json::parse_error&);
-            CHECK_THROWS_WITH(j.contains("/01"_json_pointer),
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
-            CHECK_THROWS_AS(j_const.contains("/01"_json_pointer), json::parse_error&);
-            CHECK_THROWS_WITH(j_const.contains("/01"_json_pointer),
-                              "[json.exception.parse_error.106] parse error: array index '01' must not begin with '0'");
+
+            CHECK(not j.contains("/01"_json_pointer));
+            CHECK(not j.contains("/01"_json_pointer));
+            CHECK(not j_const.contains("/01"_json_pointer));
+            CHECK(not j_const.contains("/01"_json_pointer));
 
             // error with incorrect numbers
             CHECK_THROWS_AS(j["/one"_json_pointer] = 1, json::parse_error&);
@@ -360,12 +359,10 @@ TEST_CASE("JSON pointers")
             CHECK_THROWS_WITH(j_const.at("/one"_json_pointer) == 1,
                               "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
 
-            CHECK_THROWS_AS(j.contains("/one"_json_pointer), json::parse_error&);
-            CHECK_THROWS_WITH(j.contains("/one"_json_pointer),
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
-            CHECK_THROWS_AS(j_const.contains("/one"_json_pointer), json::parse_error&);
-            CHECK_THROWS_WITH(j_const.contains("/one"_json_pointer),
-                              "[json.exception.parse_error.109] parse error: array index 'one' is not a number");
+            CHECK(not j.contains("/one"_json_pointer));
+            CHECK(not j.contains("/one"_json_pointer));
+            CHECK(not j_const.contains("/one"_json_pointer));
+            CHECK(not j_const.contains("/one"_json_pointer));
 
             CHECK_THROWS_AS(json({{"/list/0", 1}, {"/list/1", 2}, {"/list/three", 3}}).unflatten(), json::parse_error&);
             CHECK_THROWS_WITH(json({{"/list/0", 1}, {"/list/1", 2}, {"/list/three", 3}}).unflatten(),


### PR DESCRIPTION
[Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.]

* * *

## Pull request checklist

Read the [Contribution Guidelines](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md) for detailed information.

- [ ]  Changes are described in the pull request, or an [existing issue is referenced](https://github.com/nlohmann/json/issues).
- [ ]  The test suite [compiles and runs](https://github.com/nlohmann/json/blob/develop/README.md#execute-unit-tests) without error.
- [ ]  [Code coverage](https://coveralls.io/github/nlohmann/json) is 100%. Test cases can be added by editing the [test suite](https://github.com/nlohmann/json/tree/develop/test/src).
- [ ]  The source code is amalgamated; that is, after making changes to the sources in the `include/nlohmann` directory, run `make amalgamate` to create the single-header file `single_include/nlohmann/json.hpp`. The whole process is described [here](https://github.com/nlohmann/json/blob/develop/.github/CONTRIBUTING.md#files-to-change).

## Please don't

- The C++11 support varies between different **compilers** and versions. Please note the [list of supported compilers](https://github.com/nlohmann/json/blob/master/README.md#supported-compilers). Some compilers like GCC 4.7 (and earlier), Clang 3.3 (and earlier), or Microsoft Visual Studio 13.0 and earlier are known not to work due to missing or incomplete C++11 support. Please refrain from proposing changes that work around these compiler's limitations with `#ifdef`s or other means.
- Specifically, I am aware of compilation problems with **Microsoft Visual Studio** (there even is an [issue label](https://github.com/nlohmann/json/issues?utf8=✓&q=label%3A%22visual+studio%22+) for these kind of bugs). I understand that even in 2016, complete C++11 support isn't there yet. But please also understand that I do not want to drop features or uglify the code just to make Microsoft's sub-standard compiler happy. The past has shown that there are ways to express the functionality such that the code compiles with the most recent MSVC - unfortunately, this is not the main objective of the project.
- Please refrain from proposing changes that would **break [JSON](https://json.org) conformance**. If you propose a conformant extension of JSON to be supported by the library, please motivate this extension.
- Please do not open pull requests that address **multiple issues**.
