### PR TITLE
Upgrade CI image version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 # C++ project
 language: cpp
 
-dist: trusty
+dist: xenial
 sudo: required
 group: edge
 
@@ -48,7 +48,7 @@ matrix:
       - UBSAN_OPTIONS=print_stacktrace=1,suppressions=$(pwd)/test/src/UBSAN.supp
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-7']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-7']
         packages: ['g++-6', 'clang-7', 'ninja-build']
     before_script:
       - export PATH=$PATH:/usr/lib/llvm-7/bin
@@ -116,7 +116,7 @@ matrix:
     before_install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-certificates.crt
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.6']
         packages: ['g++-6', 'clang-3.6', 'ninja-build']
       coverity_scan:
         project:
@@ -225,7 +225,7 @@ matrix:
     env: COMPILER=clang++-3.5
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.5']
         packages: ['g++-6', 'clang-3.5', 'ninja-build']
 
   - os: linux
@@ -233,7 +233,7 @@ matrix:
     env: COMPILER=clang++-3.6
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.6']
         packages: ['g++-6', 'clang-3.6', 'ninja-build']
 
   - os: linux
@@ -241,7 +241,7 @@ matrix:
     env: COMPILER=clang++-3.7
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.7']
         packages: ['g++-6', 'clang-3.7', 'ninja-build']
 
   - os: linux
@@ -265,7 +265,7 @@ matrix:
     env: COMPILER=clang++-4.0
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-4.0']
         packages: ['g++-6', 'clang-4.0', 'ninja-build']
 
   - os: linux
@@ -273,7 +273,7 @@ matrix:
     env: COMPILER=clang++-5.0
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-5.0']
         packages: ['g++-6', 'clang-5.0', 'ninja-build']
 
   - os: linux
@@ -281,7 +281,7 @@ matrix:
     env: COMPILER=clang++-6.0
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-6.0']
         packages: ['g++-6', 'clang-6.0', 'ninja-build']
 
   - os: linux
@@ -289,7 +289,7 @@ matrix:
     env: COMPILER=clang++-7
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-7']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-7']
         packages: ['g++-6', 'clang-7', 'ninja-build']
 
   - os: linux
@@ -299,7 +299,7 @@ matrix:
       - CXXFLAGS=-std=c++1z
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-7']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-7']
         packages: ['g++-6', 'clang-7', 'ninja-build']
 
 ################


### PR DESCRIPTION
As stated in [travis docs](https://docs.travis-ci.com/user/reference/precise/):
> Trusty is EOL by Canonical, try updating to a newer image and see our Trusty to Xenial Migration Guide.

we should upgrade Precise and Trusty to Xenial.