### PR TITLE
fix problems in PR2117

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,6 +218,17 @@ matrix:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['g++-9', 'ninja-build']
 
+  - os: linux
+    compiler: gcc
+    env:
+      - COMPILER=g++-9
+      - CXXFLAGS=-std=c++17
+      - CMAKECXXSTANDARD=17
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test']
+        packages: ['g++-9', 'ninja-build']
+
   # Linux / Clang
 
   - os: linux
@@ -328,7 +339,11 @@ script:
 
   # compile and execute unit tests
   - mkdir -p build && cd build
-  - cmake .. ${CMAKE_OPTIONS} -DJSON_MultipleHeaders=${MULTIPLE_HEADERS} -GNinja && cmake --build . --config Release
+  - if [[ "${CMAKECXXSTANDARD}" != "" ]]; then
+    cmake .. ${CMAKE_OPTIONS} -DJSON_MultipleHeaders=${MULTIPLE_HEADERS} -DCMAKE_CXX_STANDARD=${CMAKECXXSTANDARD} -GNinja && cmake --build . --config Release ;
+    else
+    cmake .. ${CMAKE_OPTIONS} -DJSON_MultipleHeaders=${MULTIPLE_HEADERS} -GNinja && cmake --build . --config Release ;
+    fi
   - ctest -C Release --timeout 2700 -V -j
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -223,7 +223,7 @@ matrix:
     env:
       - COMPILER=g++-9
       - CXXFLAGS=-std=c++17
-      - CMAKECXXSTANDARD=17
+      - CMAKE_CXX_STANDARD=17
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -339,8 +339,8 @@ script:
 
   # compile and execute unit tests
   - mkdir -p build && cd build
-  - if [[ "${CMAKECXXSTANDARD}" != "" ]]; then
-    cmake .. ${CMAKE_OPTIONS} -DJSON_MultipleHeaders=${MULTIPLE_HEADERS} -DCMAKE_CXX_STANDARD=${CMAKECXXSTANDARD} -GNinja && cmake --build . --config Release ;
+  - if [[ "${CMAKE_CXX_STANDARD}" != "" ]]; then
+    cmake .. ${CMAKE_OPTIONS} -DJSON_MultipleHeaders=${MULTIPLE_HEADERS} -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} -GNinja && cmake --build . --config Release ;
     else
     cmake .. ${CMAKE_OPTIONS} -DJSON_MultipleHeaders=${MULTIPLE_HEADERS} -GNinja && cmake --build . --config Release ;
     fi

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -1746,7 +1746,8 @@ TEST_CASE("std::optional")
         std::vector<std::optional<int>> opt_array = {{1, 2, std::nullopt}};
 
         CHECK(json(opt_array) == j_array);
-        CHECK(std::vector<std::optional<int>>(j_array) == opt_array);
+        std::vector<std::optional<int>> tmp = j_array;
+        CHECK(tmp == opt_array);
     }
 
     SECTION("object")
@@ -1755,7 +1756,8 @@ TEST_CASE("std::optional")
         std::map<std::string, std::optional<int>> opt_object {{"one", 1}, {"two", 2}, {"zero", std::nullopt}};
 
         CHECK(json(opt_object) == j_object);
-        CHECK(std::map<std::string, std::optional<int>>(j_object) == opt_object);
+        std::map<std::string, std::optional<int>> tmp =j_object;
+        CHECK(tmp == opt_object);
     }
 }
 #endif

--- a/test/src/unit-conversions.cpp
+++ b/test/src/unit-conversions.cpp
@@ -1710,7 +1710,8 @@ TEST_CASE("std::optional")
         std::optional<std::string> opt_null;
 
         CHECK(json(opt_null) == j_null);
-        CHECK(std::optional<std::string>(j_null) == std::nullopt);
+        CHECK_THROWS_WITH(std::optional<std::string>(j_null) == std::nullopt,
+                          "[json.exception.type_error.302] type must be string, but is null");
     }
 
     SECTION("string")


### PR DESCRIPTION
This PR would fix some problems in PR#2117.

1. It would solve the AppVeyor compile error. Probably it is a bug in the VS compiler.

2. As https://github.com/nlohmann/json/pull/2117#issuecomment-634475426 said, I found some problems.

2.a. I used these code to detect but just found `JSON_HAS_CPP_17 = False` in all travis jobs.
```
#ifdef JSON_HAS_CPP_17
    std::cout << "JSON_HAS_CPP_17 = True" << std::endl;
#else
	std::cout << "JSON_HAS_CPP_17 = Flase" << std::endl;
#endif
```
Thus, All travis jobs didn't run the testcase - `TEST_CASE("std::optional")`, and those all code about `optional` were not compiled.

**I add a new travis task for c++17.**

2.b. I also found the actual behavior, which would also happen in linux:
```
CHECK(std::optional<std::string>(j_string) == opt_string);  // call from_json(const BasicJsonType& j, ConstructibleStringType& s)
CHECK(std::optional<bool>(j_bool) == opt_bool); // call from_json(const BasicJsonType& j, typename BasicJsonType::boolean_t& b) 
CHECK(std::optional<int>(j_number) == opt_int); // call from_json(const BasicJsonType& j, ArithmeticType& val)
```
And the testcase `SECTION("null")` didn't call the expected method either and raise an excepiton - `"[json.exception.type_error.302] type must be object, but is null"`.

I agree with [this view](https://stackoverflow.com/questions/45861479/why-is-a-cast-operator-to-stdoptional-ignored):
> The reason is the template<typename U> optional(U&&) constructor template, which is supposed to activate when T (int) is constructible from U and U is neither std::in_place_t nor optional<T>, and direct-initialize T from it. And so it does, stamping out optional(foo&).

Thus, they would not call the method `from_json(basi_json, std::option<T>)` never. This is why an exception is raised in `SECTION("null")`.

Related Problem:
 [Different results in Clang and GCC when casting to std::optional<T>](https://stackoverflow.com/questions/45843428/different-results-in-clang-and-gcc-when-casting-to-stdoptionalt)
[Why is a cast operator to std::optional ignored?](https://stackoverflow.com/questions/45861479/why-is-a-cast-operator-to-stdoptional-ignored/45865802#45865802)
[specification of std::optional constructor regarding cast operators](https://groups.google.com/a/isocpp.org/forum/embed/?place=forum/std-discussion&showsearch=true&showpopout=true&parenturl=https://isocpp.org/forums/iso-c-standard-discussion#!topic/std-discussion/r5CY7HnnD8Y)